### PR TITLE
Support IANA timezones (also fix compiler errors etc)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/StatusSheetPlus/src/main/kotlin/me/aniimalz/plugins/StatusSheet.kt
+++ b/StatusSheetPlus/src/main/kotlin/me/aniimalz/plugins/StatusSheet.kt
@@ -273,10 +273,16 @@ class StatusSheet(private val logger: Logger) : BottomSheet() {
 
                     // kanged from dps
                     try {
-                        val args = h?.settingsTab?.args ?: emptyArray()
-                        if (h != null) {
-                            ReflectUtils.invokeConstructorWithArgs(h.settingsTab.page, *args).let {
-                                Utils.openPageWithProxy(ctx, it)
+                        h?.settingsTab?.let { tab ->
+                            val pageClass = tab.page
+                            val args = tab.args ?: emptyArray()
+
+                            if (pageClass != null) {
+                                val fragmentInstance = ReflectUtils.invokeConstructorWithArgs(pageClass, *args)
+
+                                fragmentInstance?.let {
+                                    Utils.openPageWithProxy(ctx, it)
+                                }
                             }
                         }
                     } catch (th: Throwable) {

--- a/Timezones/build.gradle.kts
+++ b/Timezones/build.gradle.kts
@@ -1,8 +1,11 @@
-version = "1.2.3"
+version = "1.3.0"
 description = "Allows you to set a timezone for a user and view their time"
 
 aliucord {
     changelog.set("""
+        # 1.3.0
+        Support IANA timezones (daylight savings finally real)
+		
         # 1.2.3
         Show user's local time at sending time in message headers (#35)
         or something... i dont remember havent plugin dev in years

--- a/Timezones/src/main/kotlin/me/aniimalz/plugins/Stuff.kt
+++ b/Timezones/src/main/kotlin/me/aniimalz/plugins/Stuff.kt
@@ -8,60 +8,43 @@ import java.util.*
 const val apiUrl = "https://timezonedb.catvibers.me"
 
 fun calculateTime(timezone: String?, date: Date? = null): String {
-    val tz = TimeZone.getTimeZone("GMT$timezone")
-    val cal = Calendar.getInstance(tz)
+    if (timezone == null) return "00:00"
+    
+    val isOffset = timezone.matches(Regex("""^[+-]\d{1,2}(:?\d{2})?$"""))
+    val tzId = if (isOffset) "GMT$timezone" else timezone
 
-    val dateFormat = if (DateFormat.is24HourFormat(Utils.appContext)) {
-        SimpleDateFormat("HH:mm", Locale.getDefault())
-    } else {
-        SimpleDateFormat("hh:mm a", Locale.getDefault())
-    }
+    val tz = TimeZone.getTimeZone(tzId)
+    val cal = Calendar.getInstance(tz)
+    if (date != null) cal.time = date
+
+    val is24Hour = DateFormat.is24HourFormat(Utils.appContext)
+    val pattern = if (is24Hour) "HH:mm" else "hh:mm a"
+    val dateFormat = SimpleDateFormat(pattern, Locale.getDefault())
 
     dateFormat.timeZone = tz
-    return dateFormat.format(date ?: cal.time)
+    return dateFormat.format(cal.time)
 }
 
 fun formatTimeText(timezone: String?): String {
-    return "${calculateTime(timezone)} (UTC${timezone})"
+    return "${calculateTime(timezone)} (${timezone ?: "UTC"})"
 }
 
 val timezones = arrayOf(
-    "-12:00",
-    "-11:00",
-    "-10:00",
-    "-09:30",
-    "-09:00",
-    "-08:00",
-    "-07:00",
-    "-06:00",
-    "-05:00",
-    "-04:00",
-    "-03:30",
-    "-03:00",
-    "-02:00",
-    "-01:00",
-    "+00:00",
-    "+01:00",
-    "+02:00",
-    "+03:00",
-    "+03:30",
-    "+04:00",
-    "+04:30",
-    "+05:00",
-    "+05:30",
-    "+05:45",
-    "+06:00",
-    "+06:30",
-    "+07:00",
-    "+08:00",
-    "+08:45",
-    "+09:00",
-    "+09:30",
-    "+10:00",
-    "+10:30",
-    "+11:00",
-    "+12:00",
-    "+12:45",
-    "+13:00",
-    "+14:00"
+    "America/New_York", "America/Chicago", "America/Denver", "America/Los_Angeles", 
+    "America/Phoenix", "America/Anchorage", "America/Halifax", "America/St_Johns",
+    "America/Mexico_City", "America/Panama", "America/Bogota", "America/Lima", 
+    "America/Santiago", "America/Sao_Paulo", "America/Recife", "America/Argentina/Buenos_Aires",
+    "Europe/London", "Europe/Dublin", "Europe/Paris", "Europe/Berlin", 
+    "Europe/Rome", "Europe/Madrid", "Europe/Kyiv", "Europe/Warsaw", "Europe/Moscow",
+    "Africa/Cairo", "Africa/Johannesburg", "Africa/Lagos", "Africa/Nairobi", "Africa/Casablanca",
+    "Asia/Jerusalem", "Asia/Dubai", "Asia/Riyadh", "Asia/Tehran", "Asia/Kabul", 
+    "Asia/Kolkata", "Asia/Kathmandu", "Asia/Bangkok", "Asia/Singapore", 
+    "Asia/Shanghai", "Asia/Tokyo", "Asia/Seoul", "Asia/Jakarta",
+    "Australia/Perth", "Australia/Adelaide", "Australia/Darwin", "Australia/Sydney", 
+    "Australia/Brisbane", "Pacific/Auckland", "Pacific/Fiji", "Pacific/Honolulu",
+	"-12:00", "-11:00", "-10:00", "-09:30", "-09:00", "-08:00", "-07:00", "-06:00",
+	"-05:00", "-04:00", "-03:30", "-03:00", "-02:00", "-01:00", "+00:00", "+01:00",
+	"+02:00", "+03:00", "+03:30", "+04:00", "+04:30", "+05:00", "+05:30", "+05:45",
+	"+06:00", "+06:30", "+07:00", "+08:00", "+08:45", "+09:00", "+09:30", "+10:00",
+	"+10:30", "+11:00", "+12:00", "+12:45", "+13:00", "+14:00"
 )

--- a/Timezones/src/main/kotlin/me/aniimalz/plugins/Timezones.kt
+++ b/Timezones/src/main/kotlin/me/aniimalz/plugins/Timezones.kt
@@ -174,7 +174,6 @@ class Timezones : Plugin() {
         }
     }
 
-
     @SuppressLint("SetTextI18n", "SimpleDateFormat")
     private fun setOnClick(
         tzView: TextView,
@@ -185,11 +184,34 @@ class Timezones : Plugin() {
             with(tzView) {
                 val user = loaded.user
                 setOnClickListener {
+                    val displayItems = timezones.map { id ->
+                        val isNamed = id.contains("/")
+                        if (isNamed) {
+                            val tz = TimeZone.getTimeZone(id)
+							val isDaylight = tz.inDaylightTime(Date())
+							
+                            val name = tz.getDisplayName(isDaylight, TimeZone.SHORT, Locale.US).let { usName ->
+                                if (usName.startsWith("GMT")) {
+                                    tz.getDisplayName(isDaylight, TimeZone.SHORT, Locale.UK) //show timezone abbreviations for Europe
+                                } else {
+                                    usName
+                                }
+                            }
+							
+                            "$id ($name)"
+                        } else {
+                            "GMT$id"
+                        }
+                    }.toTypedArray()
+
                     SelectDialog().apply {
-                        title = "Set timezone (UTC)"
-                        items = timezones
-                        onResultListener = cringe@{ tz ->
-                            addUser(user.id, timezones[tz])
+                        title = "Set timezone (IANA or GMT)"
+                        items = displayItems
+                        
+                        onResultListener = cringe@{ index ->
+                            val selectedId = timezones[index]
+                            
+                            addUser(user.id, selectedId)
                             setUserSheetTime(
                                 user,
                                 tzView

--- a/UnknownConnectionIcons/build.gradle.kts
+++ b/UnknownConnectionIcons/build.gradle.kts
@@ -1,2 +1,2 @@
-version = "1.4.0"
+version = "1.4.1"
 description = "(tries to) Add icons for connections unsupported by Discord Kotlin"

--- a/UnknownConnectionIcons/src/main/kotlin/me/aniimalz/plugins/UnknownConnectionIcons.kt
+++ b/UnknownConnectionIcons/src/main/kotlin/me/aniimalz/plugins/UnknownConnectionIcons.kt
@@ -79,17 +79,23 @@ class UnknownConnectionIcons : Plugin() {
     }
 
     private fun determineTheme(ctx: Context, account: ConnectedAccount): Drawable {
+        val res = resources ?: return ContextCompat.getDrawable(ctx, R.e.ic_activity_status_24dp)!!
+    
         var result: Drawable? = null
         try {
-            val icon = if (StoreStream.getUserSettingsSystem().theme == "dark") {
+            val iconName = account.g()
+            val theme = StoreStream.getUserSettingsSystem().theme
+
+            val icon = if (theme == "dark") {
                 ResourcesCompat.getDrawable(
-                    resources,
-                    resources.getIdentifier(account.g(), "drawable", "me.aniimalz.plugins"), null
+                    res,
+                    res.getIdentifier(iconName, "drawable", "me.aniimalz.plugins"), 
+                    null
                 )
             } else {
                 ResourcesCompat.getDrawable(
-                    resources,
-                    resources.getIdentifier("${account.g()}_light", "drawable", "me.aniimalz.plugins"),
+                    res,
+                    res.getIdentifier("${iconName}_light", "drawable", "me.aniimalz.plugins"),
                     null
                 )
             }

--- a/UnknownConnectionIcons/src/main/kotlin/me/aniimalz/plugins/UnknownConnectionIcons.kt
+++ b/UnknownConnectionIcons/src/main/kotlin/me/aniimalz/plugins/UnknownConnectionIcons.kt
@@ -83,7 +83,7 @@ class UnknownConnectionIcons : Plugin() {
     
         var result: Drawable? = null
         try {
-            val iconName = account.g()
+            val iconName = account.g().replace("-", "")
             val theme = StoreStream.getUserSettingsSystem().theme
 
             val icon = if (theme == "dark") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+		maven("https://maven.aliucord.com/releases")
         maven("https://maven.aliucord.com/snapshots")
         gradlePluginPortal() // remove when gradle 8
         maven("https://jitpack.io")
@@ -12,7 +13,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.1.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
-        classpath("com.github.Aliucord:gradle:main-SNAPSHOT")
+        classpath("com.aliucord:gradle:753ad25")
         //classpath("com.gradleup.shadow:shadow-gradle-plugin:8.3.8")
         classpath("com.github.johnrengelman.shadow:com.github.johnrengelman.shadow.gradle.plugin:7.1.2") // For Gradle 7 compat (allegedly)
     }
@@ -78,7 +79,7 @@ subprojects {
         val discord by configurations
         val implementation by configurations
 
-        discord("com.discord:discord:aliucord-SNAPSHOT")
+        discord("com.discord:discord:126021")
         implementation("com.aliucord:Aliucord:2.4.0")
     }
 }


### PR DESCRIPTION
<img width="415" height="573" alt="image" src="https://github.com/user-attachments/assets/32e3e2ba-c489-4bb5-b4d1-d9612b09b24f" />

Now besides the usual GMT offsets, you can also set common IANA timezones which will respect Daylight Savings automatically, with NA and EU short handles between parenthesis to help selection (that also follow daylight savings). It's still possible to set GMT offsets and it's still compatible with existing settings or TimezoneDB. Fixes https://github.com/nyakowint/AliuPlugins/issues/39.

Also fixed compiler errors in other plugins and Amazon Music icon not working due to its internal name changing to `amazon-music`.